### PR TITLE
upload images with no slash in their path (inc. diagrams) as attachments

### DIFF
--- a/lib/asciidoctor/page.rb
+++ b/lib/asciidoctor/page.rb
@@ -4,7 +4,7 @@ class Page
   REPRESENTATION = 'storage'
   @document
 
-  attr_reader :page_id, :title, :space_key
+  attr_reader :page_id, :title, :space_key, :document
   attr_writer :revision
 
   def initialize(space_key, title, document, page_id)


### PR DESCRIPTION
This should help with #6 
Current limitation: this cannot update an image, you have to rename it if you want this to work.

Tested with

```
[ditaa]
[plantuml]
image::path.png[Description]
image::path.jpg[Description]
```