### PR TITLE
add insecure option for disable ssl certificate verification

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,6 +72,12 @@ Here is the list of arguments that can used with this gem
 |no
 |The ID of the page you want to update, if it's not provided it will be determined using the space key and the title
 |
+
+|insecure
+|false
+|Disable SSL certificate verification. It may be usefull if server uses self-signed certificate.
+No values are required for this option
+|
 |===
 
 

--- a/lib/asciidoctor/confluence/options.rb
+++ b/lib/asciidoctor/confluence/options.rb
@@ -12,7 +12,7 @@ module Asciidoctor
 
       def initialize(options = {})
         super options
-        self[:confluence] = options[:confluence] || {:update => false}
+        self[:confluence] = options[:confluence] || {:update => false, :insecure => false}
         self[:confluence][:auth] = {} if self[:confluence][:auth].nil?
       end
 
@@ -60,6 +60,10 @@ Usage: asciidoctor-confluence --host HOSTNAME --spaceKey SPACEKEY --title TITLE 
 
           opts.on('--password PASSWORD', 'the password used if credential are need to create the page') do |spaceKey|
             self[:confluence][:auth][:password] = spaceKey
+          end
+
+          opts.on('--insecure', 'disable SSL certificate verification') do
+            self[:confluence][:insecure] = true
           end
 
           opts.on_tail('-h', '--help', 'Show the full helper (including Asciidoctor helper)') do

--- a/lib/asciidoctor/confluence_api.rb
+++ b/lib/asciidoctor/confluence_api.rb
@@ -8,11 +8,13 @@ module Asciidoctor
       attr_reader :url
       @page
       @auth
+      @verify
 
       def initialize(confluence_options, page)
         @url = build_api_content_url(confluence_options)
         @auth = confluence_options[:auth] unless confluence_options[:auth].nil?
         @page = page
+        @verify = !confluence_options[:insecure]
       end
 
       def build_api_content_url(confluence_options)
@@ -25,6 +27,7 @@ module Asciidoctor
         conn = Faraday.new do |faraday|
           faraday.request :url_encoded
           faraday.adapter Faraday.default_adapter
+          faraday.ssl.verify = @verify
         end
 
         conn.basic_auth(@auth[:username], @auth[:password]) unless @auth.nil?


### PR DESCRIPTION
I add  --insecure option for skipping ssl certificate verification.
It is useful for servers with  self-signed certificates.