### PR TITLE
Add bearer authentication support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-:version: 0.0.2
+:version: 0.0.3
 :asciidoctor-base-version: 1.5.2
 :confluence-version: 5.x
 
@@ -61,6 +61,11 @@ Here is the list of arguments that can used with this gem
 |password
 |no
 |The password associated to the account used to login into Confluence
+|
+
+|bearerAuth
+|no
+|The Authorization Bearer token associated to the account used to login into Confluence
 |
 
 |update

--- a/lib/asciidoctor/confluence/options.rb
+++ b/lib/asciidoctor/confluence/options.rb
@@ -61,6 +61,10 @@ Usage: asciidoctor-confluence --host HOSTNAME --spaceKey SPACEKEY --title TITLE 
           opts.on('--password PASSWORD', 'the password used if credential are need to create the page') do |spaceKey|
             self[:confluence][:auth][:password] = spaceKey
           end
+          
+          opts.on('--bearerAuth TOKEN', 'the token used if Bearer Authentication is required to create the page') do |token|
+            self[:confluence][:auth][:token] = token
+          end
 
           opts.on_tail('-h', '--help', 'Show the full helper (including Asciidoctor helper)') do
             $stdout.puts opts, "\n\n"

--- a/lib/asciidoctor/confluence/version.rb
+++ b/lib/asciidoctor/confluence/version.rb
@@ -1,5 +1,5 @@
 module Asciidoctor
   module Confluence
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/lib/asciidoctor/confluence_api.rb
+++ b/lib/asciidoctor/confluence_api.rb
@@ -27,7 +27,16 @@ module Asciidoctor
           faraday.adapter Faraday.default_adapter
         end
 
-        conn.basic_auth(@auth[:username], @auth[:password]) unless @auth.nil?
+        if @auth.nil?
+          return conn
+        end
+
+        if @auth[:token].nil? 
+          conn.basic_auth(@auth[:username], @auth[:password])
+        else
+          conn.authorization :Bearer, @auth[:token]
+          conn.headers['Authorization']
+        end
         conn
       end
 

--- a/test/Asciidoctor/confluence/options_tests.rb
+++ b/test/Asciidoctor/confluence/options_tests.rb
@@ -31,6 +31,14 @@ class OptionsTests < Test::Unit::TestCase
     assert_equal password, options[:confluence][:auth][:password]
   end
 
+  def test_init_options_with_token
+    options = Asciidoctor::Confluence::Options.new
+    token = 'sometoken'
+    options.init_options ['--host', 'http://hostname', '--spaceKey', 'key', '--title', 'title', '--bearerAuth', token, 'file.adoc']
+
+    assert_equal token, options[:confluence][:auth][:token]
+  end
+  
   def test_with_full_options
     args = {:confluence => {:host => 'http://hostname/', :space_key => 'TEST_KEY', :title =>'Test title'}}
     options = Asciidoctor::Confluence::Options.new args


### PR DESCRIPTION
Currently only basic authentication is supported. This PR adds the option --bearerAuth to specify a Bearer Token